### PR TITLE
グループ新規作成の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'annotate'
+  gem 'bullet'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,5 @@ gem "font-awesome-rails"
 
 gem "devise"
 
+gem 'draper'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,9 @@ GEM
     bcrypt (3.1.11)
     bindex (0.5.0)
     builder (3.2.3)
+    bullet (5.6.1)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.10.0)
     byebug (9.1.0)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -184,6 +187,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
+    uniform_notifier (1.10.0)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.5.1)
@@ -200,6 +204,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
+  bullet
   byebug
   coffee-rails (~> 4.2)
   devise

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (5.0.6)
       activesupport (= 5.0.6)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (5.0.6)
       activemodel (= 5.0.6)
       activesupport (= 5.0.6)
@@ -64,6 +68,12 @@ GEM
       railties (>= 4.1.0, < 5.2)
       responders
       warden (~> 1.2.3)
+    draper (3.0.1)
+      actionpack (~> 5.0)
+      activemodel (~> 5.0)
+      activemodel-serializers-xml (~> 1.0)
+      activesupport (~> 5.0)
+      request_store (~> 1.0)
     erb2haml (0.1.5)
       html2haml
     erubis (2.7.0)
@@ -148,6 +158,7 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    request_store (1.3.2)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -208,6 +219,7 @@ DEPENDENCIES
   byebug
   coffee-rails (~> 4.2)
   devise
+  draper
   erb2haml
   faker
   font-awesome-rails

--- a/app/assets/stylesheets/_variable.scss
+++ b/app/assets/stylesheets/_variable.scss
@@ -1,7 +1,0 @@
-@mixin clearfix {
-                  &:after {
-                    content: "";
-                    display: block;
-                    clear: both;
-                  }
-}

--- a/app/assets/stylesheets/_variable.scss
+++ b/app/assets/stylesheets/_variable.scss
@@ -1,0 +1,7 @@
+@mixin clearfix {
+                  &:after {
+                    content: "";
+                    display: block;
+                    clear: both;
+                  }
+}

--- a/app/controllers/chat_groups_controller.rb
+++ b/app/controllers/chat_groups_controller.rb
@@ -7,12 +7,10 @@ class ChatGroupsController < ApplicationController
 
   def create
     @chat_group = ChatGroup.new(chat_group_params)
-    respond_to do |format|
-      if @chat_group.save
-        format.html { redirect_to root_path, notice: 'グループを作成しました' }
-      else
-        format.html { render :new }
-      end
+    if @chat_group.save
+      redirect_to root_path, notice: 'グループを作成しました'
+    else
+      render :new
     end
   end
 

--- a/app/controllers/chat_groups_controller.rb
+++ b/app/controllers/chat_groups_controller.rb
@@ -5,12 +5,12 @@ class ChatGroupsController < ApplicationController
   end
 
   def create
-    chat_group = ChatGroup.new(chat_group_params)
+    @chat_group = ChatGroup.new(chat_group_params)
     respond_to do |format|
-      if chat_group.save
+      if @chat_group.save
         format.html { redirect_to root_path, notice: 'グループを作成しました' }
       else
-        format.html { redirect_to root_path, alert: '作成に失敗しました' }
+        format.html { render :new }
       end
     end
   end

--- a/app/controllers/chat_groups_controller.rb
+++ b/app/controllers/chat_groups_controller.rb
@@ -6,7 +6,8 @@ class ChatGroupsController < ApplicationController
   end
 
   def create
-    @chat_group = ChatGroup.new(chat_group_params)
+    source = ChatGroup.new(chat_group_params)
+    @chat_group = ChatGroupDecorator.decorate(source)
     if @chat_group.save
       redirect_to root_path, notice: 'グループを作成しました'
     else

--- a/app/controllers/chat_groups_controller.rb
+++ b/app/controllers/chat_groups_controller.rb
@@ -4,10 +4,24 @@ class ChatGroupsController < ApplicationController
     @chat_group = ChatGroup.new
   end
 
-  def create; end
+  def create
+    chat_group = ChatGroup.new(chat_group_params)
+    respond_to do |format|
+      if chat_group.save
+        format.html { redirect_to root_path, notice: 'グループを作成しました' }
+      else
+        format.html { redirect_to root_path, alert: '作成に失敗しました' }
+      end
+    end
+  end
 
   def edit; end
 
   def update; end
+
+  private
+  def chat_group_params
+    params.require(:chat_group).permit(:name, user_ids: [] )
+  end
 
 end

--- a/app/controllers/chat_groups_controller.rb
+++ b/app/controllers/chat_groups_controller.rb
@@ -1,6 +1,8 @@
 class ChatGroupsController < ApplicationController
 
-  def new; end
+  def new
+    @chat_group = ChatGroup.new
+  end
 
   def create; end
 

--- a/app/controllers/chat_groups_controller.rb
+++ b/app/controllers/chat_groups_controller.rb
@@ -1,4 +1,5 @@
 class ChatGroupsController < ApplicationController
+  before_action :authenticate_user!
 
   def new
     @chat_group = ChatGroup.new

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,7 +2,7 @@ class MessagesController < ApplicationController
   before_action :authenticate_user!, only: [:index]
 
   def index
-    @chat_groups = current_user.chat_groups
+    @chat_groups = ChatGroupDecorator.decorate_collection(current_user.chat_groups)
   end
 
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,5 +1,9 @@
 class MessagesController < ApplicationController
   before_action :authenticate_user!, only: [:index]
 
-  def index; end
+  def index
+    @chat_groups = current_user.chat_groups
+  end
+
 end
+

--- a/app/decorators/chat_group_decorator.rb
+++ b/app/decorators/chat_group_decorator.rb
@@ -1,0 +1,21 @@
+class ChatGroupDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+  def name
+    object.name
+  end
+
+  def errors_count
+    
+  end
+
+end

--- a/app/decorators/chat_group_decorator.rb
+++ b/app/decorators/chat_group_decorator.rb
@@ -15,7 +15,7 @@ class ChatGroupDecorator < Draper::Decorator
   end
 
   def errors_count
-    
+    object.errors.count
   end
 
 end

--- a/app/decorators/chat_group_decorator.rb
+++ b/app/decorators/chat_group_decorator.rb
@@ -1,15 +1,6 @@
 class ChatGroupDecorator < Draper::Decorator
   delegate_all
 
-  # Define presentation-specific methods here. Helpers are accessed through
-  # `helpers` (aka `h`). You can override attributes, for example:
-  #
-  #   def created_at
-  #     helpers.content_tag :span, class: 'time' do
-  #       object.created_at.strftime("%a %m/%d/%y")
-  #     end
-  #   end
-
   def name
     object.name
   end

--- a/app/models/chat_group.rb
+++ b/app/models/chat_group.rb
@@ -11,5 +11,5 @@
 class ChatGroup < ApplicationRecord
   has_many :chat_group_users
   has_many :users, through: :chat_group_users
-  accepts_nested_attributes_for :chat_group_users
+  accepts_nested_attributes_for :users, allow_destroy: true
 end

--- a/app/models/chat_group.rb
+++ b/app/models/chat_group.rb
@@ -13,6 +13,5 @@ class ChatGroup < ApplicationRecord
   has_many :users, through: :chat_group_users
   accepts_nested_attributes_for :users, allow_destroy: true
 
-  validates :name, presence: true
-  validates :name, uniqueness: true
+  validates :name, presence: true, uniqueness: true
 end

--- a/app/models/chat_group.rb
+++ b/app/models/chat_group.rb
@@ -12,4 +12,7 @@ class ChatGroup < ApplicationRecord
   has_many :chat_group_users
   has_many :users, through: :chat_group_users
   accepts_nested_attributes_for :users, allow_destroy: true
+
+  validates :name, presence: true
+  validates :name, uniqueness: true
 end

--- a/app/views/chat_groups/new.html.haml
+++ b/app/views/chat_groups/new.html.haml
@@ -1,32 +1,35 @@
 .chat-group-form
   %h1 新規チャットグループ
-  %form#new_chat_group.new_chat_group{"accept-charset": "UTF-8", action: "/chat_groups", method: "post"}
+  = form_for @chat_group, id: 'new_chat_group', class:'new_chat_group' do |f|
     .chat-group-form__errors
       %h2
         1件のエラーが発生しました。
         %ul
           %li エラーです
+
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
+        = f.label :name, 'グループ名', class: 'chat-group-form__label'
       .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
+        = f.text_field :name, placeholder: 'グループ名を入力してください', id: 'chat_group_name', class: 'chat-group-form__input'
     .chat-group-form__field.clearfix
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-      /
-        <div class='chat-group-form__field--left'>
-        <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-        </div>
-        <div class='chat-group-form__field--right'>
-        <div class='chat-group-form__search clearfix'>
-        <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-        </div>
-        <div id='user-search-result'></div>
-        </div>
+      /   <div class='chat-group-form__field--left'>
+      /   <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
+      /   </div>
+      /   <div class='chat-group-form__field--right'>
+      /   <div class='chat-group-form__search clearfix'>
+      /   <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
+      /   </div>
+      /   <div id='user-search-result'></div>
+      /   </div>
+
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
+        = f.label :user_ids, 'チャットメンバー', class: 'chat-group-form__label'
       .chat-group-form__field--right
+        = f.collection_check_boxes :user_ids, User.all, :id, :name do |b|
+          = b.label { b.check_box + b.text }
         / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
         / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
         /
@@ -39,4 +42,4 @@
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
       .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/
+        =f.submit 'Save', class: 'chat-group-form__action-btn'

--- a/app/views/chat_groups/new.html.haml
+++ b/app/views/chat_groups/new.html.haml
@@ -1,11 +1,14 @@
 .chat-group-form
   %h1 新規チャットグループ
   = form_for @chat_group, id: 'new_chat_group', class:'new_chat_group' do |f|
-    .chat-group-form__errors
-      %h2
-        1件のエラーが発生しました。
-        %ul
-          %li エラーです
+    - if @chat_group.errors.any?
+      #error_explanation.chat-group-form__errors
+        %h2
+          #{ @chat_group.errors.count }件のエラーが発生しました。
+          %ul
+          - @chat_group.errors.full_messages.each do |msg|
+            %li<
+              = msg
 
     .chat-group-form__field.clearfix
       .chat-group-form__field--left

--- a/app/views/chat_groups/new.html.haml
+++ b/app/views/chat_groups/new.html.haml
@@ -4,7 +4,7 @@
     - if @chat_group.errors.any?
       #error_explanation.chat-group-form__errors
         %h2
-          #{ @chat_group.errors.count }件のエラーが発生しました。
+          #{ @chat_group.errors_count }件のエラーが発生しました。
           %ul
           - @chat_group.errors.full_messages.each do |msg|
             %li

--- a/app/views/chat_groups/new.html.haml
+++ b/app/views/chat_groups/new.html.haml
@@ -7,7 +7,7 @@
           #{ @chat_group.errors.count }件のエラーが発生しました。
           %ul
           - @chat_group.errors.full_messages.each do |msg|
-            %li<
+            %li
               = msg
 
     .chat-group-form__field.clearfix

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -8,15 +8,11 @@
       = link_to edit_user_path(current_user), class:'side-bar__user__icons--white' do
         %i.fa.fa-cog
   .side-bar__groups
-    .side-bar__groups__individual
-      %h3 現在のグループ
-      %p 最新のメッセージ
-    .side-bar__groups__individual
-      %h3 その他①グループ
-      %p まだメッセージはありません
-    .side-bar__groups__individual
-      %h3 その他②グループ
-      %p まだメッセージはありません
+    - @chat_groups.each do |group|
+      .side-bar__groups__individual
+        %h3<
+          group.name
+        %p まだメッセージはありません
 
 .main-content
   .main-content__header

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -10,7 +10,7 @@
   .side-bar__groups
     - @chat_groups.each do |group|
       .side-bar__groups__individual
-        %h3<
+        %h3
           = group.name
         %p まだメッセージはありません
 

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -11,7 +11,7 @@
     - @chat_groups.each do |group|
       .side-bar__groups__individual
         %h3<
-          group.name
+          = group.name
         %p まだメッセージはありません
 
 .main-content

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -8,11 +8,12 @@
       = link_to edit_user_path(current_user), class:'side-bar__user__icons--white' do
         %i.fa.fa-cog
   .side-bar__groups
-    - @chat_groups.each do |group|
+    - @chat_groups.each do |chat_group|
       .side-bar__groups__individual
         %h3
-          = group.name
-        %p まだメッセージはありません
+          = chat_group.name
+        %p
+          まだメッセージがありません
 
 .main-content
   .main-content__header

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,11 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Bullet用の設定
+  Bullet.enable = true
+  Bullet.alert = true
+  Bullet.bullet_logger = true
+  Bullet.console = true
+  Bullet.rails_logger = true
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,204 @@
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+    prompts:
+      day: 日
+      hour: 時
+      minute: 分
+      month: 月
+      second: 秒
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      present: は入力しないでください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: "バリデーションに失敗しました: %{errors}"
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+      other_than: は%{count}以外の値にしてください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: 、
+      two_words_connector: 、
+      words_connector: 、
+  time:
+    am: 午前
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"
+      long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      short: "%y/%m/%d %H:%M"
+    pm: 午後

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,6 +6,23 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+  activerecord:
+    errors:
+      messages:
+        taken: "がすでに存在します。"
+        record_invalid: "バリデーションに失敗しました。 %{errors}"
+    models:
+      user: ユーザー
+      chat_group: グループ
+    attributes:
+      user:
+        name: "名前"
+        email: "メールアドレス"
+        current_password: "現在のパスワード"
+        password: "パスワード"
+        password_confirmation: パスワード
+      chat_group:
+        name: "グループ名"
   date:
     abbr_day_names:
     - 日


### PR DESCRIPTION
# WHY
チャット機能を実装するにあたり、グループを作成する必要があるため。

# WHAT
- form_forを用いてビューファイルを書き換え
- chat_groups_controllerのnew/createアクションを定義
- chat_groups#createのエラーハンドリング
- エラーメッセージの表示機能を実装
- メッセージ・モデルのの日本語化
- サイドバーへのグループ一覧表示の実装

## エラー表示
<img width="1440" alt="2017-10-29 2 24 16" src="https://user-images.githubusercontent.com/26059040/32164016-89c6c614-bda1-11e7-8a3b-8d22b55a2c54.png">
<img width="1440" alt="2017-10-29 2 24 30" src="https://user-images.githubusercontent.com/26059040/32164017-8a087d3e-bda1-11e7-91f7-748a26a74c90.png">

##  グループ新規作成成功時
<img width="1440" alt="2017-10-29 2 51 48" src="https://user-images.githubusercontent.com/26059040/32164047-9d7c0566-bda1-11e7-8031-7683fc919b11.png">
